### PR TITLE
Fix the child process cwd

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -74,7 +74,7 @@ var Monitor = exports.Monitor = function (script, options) {
   this.spawnWith = options.spawnWith || {};
   this.sourceDir = options.sourceDir;
   this.fork      = options.fork || false;
-  this.cwd       = options.cwd || null;
+  this.cwd       = options.cwd || process.cwd();
   this.hideEnv   = options.hideEnv || [];
   this._env      = options.env || {};
   this._hideEnv  = {};


### PR DESCRIPTION
I had some issues with the child process getting the root dir as cwd. Somehow spawn doesn't like null values for cwd. Thus, this patch.
