### PR TITLE
Implement restart attempt backoffs.

### DIFF
--- a/lib/forever-monitor/backoff.js
+++ b/lib/forever-monitor/backoff.js
@@ -1,0 +1,18 @@
+// n + 1
+exports.incremental = function(n) {
+  return n + 1;
+};
+
+// (2^n - 1) / 2
+exports.exponential = function(n) {
+  return (Math.pow(2, n) - 1) / 2;
+};
+
+// F(n) = { 0                    n = 0
+//          1                    n = 1
+//          F(n - 1) + F(n - 2)  n > 1
+//        }
+function fibonacci_recursive(n) {
+  return n < 2 ? n : fibonacci(n - 1) + fibonacci(n - 2);
+};
+exports.fibonacci = fibonacci_recursive;

--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -14,6 +14,7 @@ var events = require('events'),
     broadway = require('broadway'),
     psTree = require('ps-tree'),
     utile = require('utile'),
+    backoff = require('./backoff'),
     common = require('./common'),
     plugins = require('./plugins');
 
@@ -64,6 +65,15 @@ var Monitor = exports.Monitor = function (script, options) {
   //
   this.minUptime     = typeof options.minUptime !== 'number' ? 0 : options.minUptime;
   this.spinSleepTime = options.spinSleepTime || null;
+
+  //
+  // Setup restart delay. Controls how quickly forever will restart
+  // a child process after it has exited.
+  //
+  this.delay = options.delay || 0;
+  this.delayMax = options.delayMax || 0;
+  this.delayAlgorithm = options.delayAlgorithm || 'incremental';
+
 
   //
   // Setup the command to spawn and the options to pass
@@ -172,9 +182,7 @@ Monitor.prototype.start = function (restart) {
 
     function restartChild() {
       self.forceRestart = false;
-      process.nextTick(function () {
-        self.start(true);
-      });
+      self.start(true);
     }
 
     self.times++;
@@ -187,7 +195,13 @@ Monitor.prototype.start = function (restart) {
       setTimeout(restartChild, self.spinSleepTime);
     }
     else {
-      restartChild();
+      if (self.delay > 0) {
+        var delay = self._computeRestartDelay();
+        self.emit('restart:delay', delay);
+        setTimeout(restartChild, delay);
+      } else {
+        process.nextTick(restartChild);
+      }
     }
   });
 
@@ -394,4 +408,22 @@ Monitor.prototype._getEnv = function () {
   });
 
   return merged;
+};
+
+//
+// ### @private function _computeRestartDelay ()
+// Returns the amount of time to delay restarting the
+// child process between restart tries.
+//
+Monitor.prototype._computeRestartDelay = function () {
+  var algorithm = this.delayAlgorithm;
+  if (typeof algorithm !== 'function') {
+    algorithm = backoff[algorithm];
+  }
+
+  var delay = algorithm(this.times - 1) * this.delay;
+  if (this.delayMax && delay > this.delayMax) {
+    return this.delayMax;
+  }
+  return delay;
 };


### PR DESCRIPTION
This provides changes to the monitor needed to implement restart attempt delays in forever.
See issue [#350](https://github.com/nodejitsu/forever/issues/350) for details on this feature request.

I have expanded the options to include: delay, delayAlgorithm, and delayMax.
These are used to control the amount of delay between trying to restart a script.
I will send a PR for forever CLI to expose these new options.

The built-in algorithms so far are: incremental, exponential, and fibonacci.
These are implemented in backoff.js. The design allows for dropping in your own
algorithms by just passing a function for the 'delayAlgorithm' option.

Right now I use the "times" variable to compute the delays. The issue with that is it doesn't get
reset back to zero after a successful launch of the script. I am not sure if the right direction is to
introduce a new variable or fix "times" to reset to zero.
