### PR TITLE
Fix watchIgnoreDotFiles initialization

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -28,11 +28,9 @@ function watchFilter(fileName) {
   }
 
   for (var key in this.watchIgnorePatterns) {
-    if (this.watchIgnorePatterns.hasOwnProperty(key)) {
-      testName = (this.watchIgnorePatterns[key].charAt(0) !== '/') ? relFileName : fileName;
-      if (minimatch(testName, this.watchIgnorePatterns[key], { matchBase: this.watchDirectory })) {
-        return false;
-      }
+    testName = (this.watchIgnorePatterns[key].charAt(0) !== '/') ? relFileName : fileName;
+    if (minimatch(testName, this.watchIgnorePatterns[key], { matchBase: this.watchDirectory })) {
+      return false;
     }
   }
 


### PR DESCRIPTION
In the original code 

lib\forever-monitor\monitor.js : 91

``` javascript
   this.watchIgnoreDotFiles = options.watchIgnoreDotFiles || true;
```

watchIgnoreDotFiles cannot be set to false
