### PR TITLE
Fix for ignore patterns

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -21,7 +21,7 @@ exports.name = 'watch';
 //
 function watchFilter(fileName) {
   var relFileName = path.relative(this.watchDirectory, fileName),
-      length = this.watchIgnorePatterns,
+      length = this.watchIgnorePatterns.length,
       testName,
       i;
 


### PR DESCRIPTION
The ".length" was left off causing the for loop to not get evaluated, essentially negating the ignore patterns and always restarting.  Related to Issue #235.
