### PR TITLE
Fix for spawnWith.cwd

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -215,7 +215,7 @@ Monitor.prototype.trySpawn = function () {
     }
   }
 
-  this.spawnWith.cwd = this.cwd || this.spawnWith.cwd;
+  this.spawnWith.cwd = this.spawnWith.cwd || this.cwd;
   this.spawnWith.env = this._getEnv();
 
   if (this.stdio) {


### PR DESCRIPTION
spawnWith.cwd was overwritten with monitor's cwd, ignoring the CLI-s `--sourceDir` parameter in forever package.

See:
[monitor.js#L218](https://github.com/nodejitsu/forever-monitor/blob/master/lib/forever-monitor/monitor.js#L218)
