### PR TITLE
fix pidFile not been writen error.

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -190,10 +190,27 @@ Monitor.prototype.start = function (restart) {
     else {
       restartChild();
     }
+    if (self.pidFile) writePid(self.pidFile, self.child ? self.child.pid : undefined, function(err){
+      if(err) self.emit('error', new Error('Open pid file error.'));
+    });
   });
 
   return this;
 };
+
+//
+// ### @function (file, pid)
+// #### @file {string} Location of the pid file.
+// #### @pid {number} pid to write to disk.
+// Write the pidFile to disk for later use
+//
+function writePid(file, pid, callback) {
+  fs.open(file, 'a', 0666, function(err, id){
+    if(err) return callback && typeof callback === 'function' ? callback(err) : null;
+    fs.writeFileSync(file, pid, 'utf8');
+    callback && typeof callback === 'function' ? callback() : null;
+  });
+}
 
 //
 // ### function trySpawn()
@@ -305,6 +322,9 @@ Monitor.prototype.__defineGetter__('data', function () {
 Monitor.prototype.restart = function () {
   this.forceRestart = true;
   this.times = 0;
+  if (this.pidFile) writePid(this.pidFile, self.child ? this.child.pid : undefined, function(err) {
+    if (err) this.emit('error', new Error('Open pid file error.'));
+  });
   return this.kill(false);
 };
 


### PR DESCRIPTION
The pid file haven't been write after the child is start 
so i add a function to add write the pid to a file use the `options.pidFile` 
