### PR TITLE
Use setMaxListeners(0) to prevent endless stream of spurious Node warnings

### DIFF
--- a/lib/forever-monitor/plugins/logger.js
+++ b/lib/forever-monitor/plugins/logger.js
@@ -62,6 +62,8 @@ exports.attach = function (options) {
       });
 
       if (!monitor.silent) {
+        process.stdout.setMaxListeners(0);
+        process.stderr.setMaxListeners(0);
         monitor.child.stdout.pipe(process.stdout, { end: false });
         monitor.child.stderr.pipe(process.stderr, { end: false });
       }


### PR DESCRIPTION
Without this, as soon as more than a few processes are monitored, I start getting an endless stream of:

(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Socket.EventEmitter.addListener (events.js:160:15)
    at Socket.Readable.on (_stream_readable.js:679:33)
    at Socket.Stream.pipe (stream.js:121:8)
    at startLogs (/usr/local/lib/node_modules/bevy/node_modules/forever-monitor/lib/forever-monitor/plugins/logger.js:66:30)
    at EventEmitter.emit (/usr/local/lib/node_modules/bevy/node_modules/forever-monitor/node_modules/broadway/node_modules/eventemitter2/lib/eventemitter2.js:332:22)
    at /usr/local/lib/node_modules/bevy/node_modules/forever-monitor/lib/forever-monitor/monitor.js:153:10
    at process._tickCallback (node.js:415:13)

It's only a warning, but it makes tracking real problems more painful.
