### PR TITLE
adding the number of restarts to what monitor returns

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -261,7 +261,8 @@ Monitor.prototype.__defineGetter__('data', function () {
     silent: this.silent,
     uid: this.uid,
     spawnWith: this.spawnWith,
-    running: this.running
+    running: this.running,
+    restarts: this.times
   };
 
   ['pidFile', 'outFile', 'errFile', 'env', 'cwd'].forEach(function (key) {


### PR DESCRIPTION
It would be very useful to have available the number of times the process has been restarted as information returned by monitor. I'm thinking of displaying this as part of the forever cli when you run `forever list`.
