### PR TITLE
Make kill wait for child process to exit, to add support for asynchronous signal handlers

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -366,12 +366,14 @@ Monitor.prototype.kill = function (forceStop) {
       }
     }
 
-    common.kill(this.child.pid, this.killTree, this.killSignal, function () {
+    this.child.on( 'exit', function () {
       self.emit('stop', self.childData);
       if (self.forceRestart && !self.running) {
         self.start(true);
       }
     });
+
+    common.kill(this.child.pid, this.killTree, this.killSignal, function() {});
   }
 
   return this;


### PR DESCRIPTION
As discussed at https://github.com/nodejitsu/forever/issues/528, forever-monitor's common.kill function immediately calls its callback, whether or not the killed process has exited. My process has an asynchronous handler for kill signals like SIGTERM, but when I told forever to stop my process (with killSignal=SIGTERM), this handler was not allowed to finish, and its output to the log file was truncated.

This change makes Monitor's kill function wait for the child process to exit, and passes a no-op function into common.kill.

Note: this change works for my purposes, but it doesn't handle complexities as discussed by @andreyst, including killTTL, killTree, and signals that are not intended to cause the child process to exit.
