### PR TITLE
hotfix: start script [windows]

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -226,7 +226,7 @@ Monitor.prototype.trySpawn = function () {
   command = this.command;
   args    = this.args;
 
-  if (cmdarr.length > 1) {
+  if (this.command !== process.execPath && cmdarr.length > 1) {
     command = cmdarr[0];
     args = cmdarr.slice(1).concat(this.args);
   }


### PR DESCRIPTION
Hi, here is a hotfix for the windows issue, when `options.command` is not specified. Then `execPath` is taken, but `process.execPath` can contain spaces, like `C:\Program Files (x86)\nodejs\node.exe`, so we have then not a valid command after `split(/\s+/)` in `trySpawn`.  

I would say, it is a hotfix, as it would be better to take the command parsing out from the `trySpawn` and do this in constructor.

Cheers, Alex.
