### PR TITLE
[windows] Move process to the background

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -218,6 +218,10 @@ Monitor.prototype.trySpawn = function () {
   this.spawnWith.cwd = this.spawnWith.cwd || this.cwd;
   this.spawnWith.env = this._getEnv();
 
+  if (process.platform === 'win32') {
+    this.spawnWith.detached = true;
+  }
+
   if (this.stdio) {
     this.spawnWith.stdio = this.stdio;
   }


### PR DESCRIPTION
Under windows there is still a terminal window, though it has no output. To move this to the background, `child_process` should be detached. 

Have added with 'windows' check, as I am not sure, what side effect it could have on linux/mac systems.

_Windows 8.1 64 Bit_
_node v0.10.24_
