### PR TITLE
fix the demo where may make confused

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There are several options that you should be aware of when using forever. Most o
     //
     // Options for restarting on watched files.
     //
-    'watch': false              // Value indicating if we should watch files.
+    'watch': true              // Value indicating if we should watch files.
     'watchIgnoreDotFiles': null // Whether to ignore file starting with a '.'
     'watchIgnorePatterns': null // Ignore patterns to use when watching files.
     'watchDirectory': null      // Top-level directory to watch from.


### PR DESCRIPTION
My friend made a mistake because of the code and comment in `README.md`.
It is easy to let know that when I want to watch files, I should write `watch: false`.
