### PR TITLE
Handle node executable paths that include whitespaces nodejitsu/forever-monitor#35

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -203,7 +203,7 @@ Monitor.prototype.start = function (restart) {
 // trying to execute a script with an env: e.g. node myfile.js
 //
 Monitor.prototype.trySpawn = function () {
-  var command, cmdarr, stats, args;
+  var command, stats, args;
 
   if (/[^\w]node$/.test(this.command) && this.checkFile && !this.childExists) {
     try {
@@ -222,13 +222,16 @@ Monitor.prototype.trySpawn = function () {
     this.spawnWith.stdio = this.stdio;
   }
 
-  cmdarr  = this.command.trim().split(/\s+/);
   command = this.command;
   args    = this.args;
 
-  if (cmdarr.length > 1) {
-    command = cmdarr[0];
-    args = cmdarr.slice(1).concat(this.args);
+  // With the assumption that the first part of the command is always the node
+  // executable, this presents a less naive way of doing argument identification
+  var commandComponents = /(.*node(?:[^\s]*)?)\s(?!$)(.*[^\s]{1})/.exec(this.command);
+  if (commandComponents !== null) {
+    // Command has arguments
+    args = commandComponents[2].split(/\s+/).concat(this.args);
+    command = commandComponents[1];
   }
 
   if (this.fork) {


### PR DESCRIPTION
Updating the command/argument detection to handle node paths which include whitespaces (such as the default node installation path on windows). This is a fix for nodejitsu/forever-monitor#35
