### PR TITLE
[feature] `isMaster` - True if the process is a master.

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -15,6 +15,7 @@ var events = require('events'),
     psTree = require('ps-tree'),
     utile = require('utile'),
     common = require('./common'),
+    cluster = require('cluster'),
     plugins = require('./plugins');
 
 //
@@ -168,6 +169,8 @@ Monitor.prototype.start = function (restart) {
   this.ctime = Date.now();
   this.child = child;
   this.running = true;
+  this.isMaster = cluster.isMaster;
+
   process.nextTick(function () {
     self.emit(restart ? 'restart' : 'start', self, self.data);
   });
@@ -278,7 +281,8 @@ Monitor.prototype.__defineGetter__('data', function () {
     id: this.id,
     spawnWith: this.spawnWith,
     running: this.running,
-    restarts: this.times
+    restarts: this.times,
+    isMaster: this.isMaster
   };
 
   ['pidFile', 'outFile', 'errFile', 'env', 'cwd'].forEach(function (key) {


### PR DESCRIPTION
I am working on `forever start process.json`, now the problem is people wanna start apps in cluster-mode, but not only spawn/fork-mode, so, I need a value to indicate whether the process is a master or not.
- cluster-mode:
  To take advantage of multi-core systems the user will sometimes want to launch a cluster of Node processes to handle the load. The process is running in worker process (not master), it does not have an UNIQUE_NODE_ID.
- spawn/fork-mode:
  A single instance of Node runs in a single thread. The process is running in master process, it has an UNIQUE_NODE_ID.
