### PR TITLE
Allow not restarting script if exits with 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ There are several options that you should be aware of when using forever. Most o
     'command': 'perl',         // Binary to run (default: 'node')
     'args':    ['foo','bar'],  // Additional arguments to pass to the script,
     'sourceDir': 'script/path',// Directory that the source script is in
+    'ignoreOkExit': false,     // Do not restart child process if it exits with code 0 (default: false)
 
     //
     // Options for restarting on watched files.

--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -56,6 +56,7 @@ var Monitor = exports.Monitor = function (script, options) {
   this.checkFile        = options.checkFile !== false;
   this.times            = 0;
   this.warn             = console.error;
+  this.ignoreOkExit     = options.ignoreOkExit || false;
 
   this.logFile          = options.logFile;
   this.outFile          = options.outFile;
@@ -205,7 +206,8 @@ Monitor.prototype.start = function (restart) {
     self.times++;
 
     if (self.forceStop || (self.times >= self.max && !self.forceRestart)
-      || (spinning && typeof self.spinSleepTime !== 'number') && !self.forceRestart) {
+      || (spinning && typeof self.spinSleepTime !== 'number')
+      || (self.ignoreOkExit && code === 0) && !self.forceRestart) {
       letChildDie();
     }
     else if (spinning) {


### PR DESCRIPTION
### Feature:

In some deployment designs, a script that exits with code 0 (zero)
    is regarded as successful, and otherwise, as failure. For example,
    the application/script can be requested (through an API, etc.) to
    shut down, thus `process.exit(0)`!

To cater for such scenarios, `ignoreOkExit` can be used to tell
    forever to ignore such successful exits. However, if the exit code
    is NOT zero, restart!
### Side-effects:

Since this design is rather rare, we should not activate this new
    behavior by default.
### Note:

Tests have NOT been updated nor broken (AFAIK).

---

Your concerns?
