### PR TITLE
Fix #140

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -245,6 +245,7 @@ Monitor.prototype.trySpawn = function () {
 
   if (process.platform === 'win32') {
     this.spawnWith.detached = true;
+    this.spawnWith.shell = true;
   }
 
   if (this.stdio) {


### PR DESCRIPTION
On Windows, `npm install -g` packages can't be run without a shell, so I opt to default to using `shell: true` in the `spawn` call to fix the issue.

See https://github.com/nodejs/node-v0.x-archive/issues/2318#issuecomment-7470062