### PR TITLE
fixed a call to chokidar in watch plugin

### DIFF
--- a/lib/forever-monitor/plugins/watch.js
+++ b/lib/forever-monitor/plugins/watch.js
@@ -74,7 +74,7 @@ exports.attach = function () {
   // Or, ignore: function(fileName) { return !watchFilter(fileName) }
   chokidar
     .watch(this.watchDirectory, opts)
-    .on('all', function(f, stat) {
+    .on('all', function(stat, f) {
       monitor.emit('watch:restart', { file: f, stat: stat });
       monitor.restart();
     });


### PR DESCRIPTION
fixed a call to chokidar. Callback to chokidar needs parameters order to be 'status', 'file'", but in the file the order is reversed.

I found this issue because when I run forever it prints:
"restarting script because change changed"
instead of showing the actual file that changed.