### PR TITLE
Upadate chokidar to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "broadway": "~0.3.6",
-    "chokidar": "^1.0.1",
+    "chokidar": "^2.1.2",
     "minimatch": "~3.0.2",
     "ps-tree": "0.0.x",
     "utile": "~0.2.1"


### PR DESCRIPTION
This pull request fixes a security vulnerability NODE-SECURITY-786 (https://nodesecurity.io/advisories/786)

The one thing killing me right now is that one test is `broken` with and without my changes. Can you weight in here?

```
When using forever-monitor an instance of Monitor with valid options setting hideEnv when spawning all-env-vars.js
    ✗ should hide the environment variables passed to the child
        » expected 1,
  	got	 0 (==) // macros.js:14
```

Thanks
Jan