### PR TITLE
Remove dependency from broadway

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -9,8 +9,8 @@
 const fs = require('fs'),
   path = require('path'),
   child_process = require('child_process'),
+  events = require('eventemitter2'),
   spawn = child_process.spawn,
-  broadway = require('broadway'),
   utile = require('utile'),
   common = require('./common'),
   cluster = require('cluster'),
@@ -136,11 +136,11 @@ const Monitor = (exports.Monitor = function(script, options) {
   // Bootstrap this instance now that options
   // have been set
   //
-  broadway.App.call(this, { bootstrapper: { bootstrap: bootstrap } });
+  bootstrap(this);
 });
 
 // Inherit from events.EventEmitter
-utile.inherits(Monitor, broadway.App);
+utile.inherits(Monitor, events.EventEmitter2);
 
 //
 // ### function start ([restart])

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "tools"
   ],
   "dependencies": {
-    "broadway": "~0.3.6",
     "chokidar": "^2.1.8",
+    "eventemitter2": "^6.4.3",
     "minimatch": "^3.0.4",
     "ps-tree": "^1.2.0",
     "utile": "^0.3.0"


### PR DESCRIPTION
Old versions of `broadway` use `minimist` which has vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2020-7598
Issue: https://github.com/foreversd/forever-monitor/issues/193
