### PR TITLE
Bugfix/honour force stop in restart

### DIFF
--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -202,6 +202,10 @@ Monitor.prototype.start = function(restart) {
     }
 
     function restartChild() {
+      if (self.forceStop) {
+        letChildDie();
+        return;
+      }
       self.forceStop = false;
       self.forceRestart = false;
       process.nextTick(function() {

--- a/lib/forever-monitor/monitor.js
+++ b/lib/forever-monitor/monitor.js
@@ -208,6 +208,7 @@ Monitor.prototype.start = function(restart) {
       }
       self.forceStop = false;
       self.forceRestart = false;
+      self.spinRestartTimeout = null;
       process.nextTick(function() {
         self.start(true);
       });
@@ -222,7 +223,7 @@ Monitor.prototype.start = function(restart) {
     ) {
       letChildDie();
     } else if (spinning) {
-      setTimeout(restartChild, self.spinSleepTime);
+      self.spinRestartTimeout = setTimeout(restartChild, self.spinSleepTime);
     } else {
       restartChild();
     }
@@ -371,6 +372,12 @@ Monitor.prototype.kill = function(forceStop) {
     // and prevent auto-restart
     //
     if (forceStop) {
+      if (self.spinRestartTimeout) {
+        clearTimeout(self.spinRestartTimeout);
+        self.spinRestartTimeout = null;
+        self.emit('stop', self.childData);
+        return;
+      }
       this.forceStop = true;
       //
       // If we have a time before we truly kill forcefully, set up a timer


### PR DESCRIPTION
Solves forever getting stuck on `stopall` and `restartall` as demonstrated by https://github.com/rubu/forever-stuck and described in https://github.com/foreversd/forever/issues/904.

The base problem is that:
1) assume there is a script that errors and exits quickly and is run with a spin time
2) while the script is being restarted a stop command arrives to the worker, if at this point the process has exited (and thus the kill call on the current pid will fail) no exit event will be emitted but the next restart queued by the spin timer will reset force close, thus the client waiting on stop will hang

This PR basically handles a pending restart timer in the stop call and also honours a pending force restart in the restart flow - since the start is queued by nextTick there is a small chance that a stop could still arrive after restartChild has just completed (thus no timer) but the process has not yet been started and thus again using the existing pid would fail.